### PR TITLE
Implementação funcional (e simples!) de plugins para o backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@ The thought of human invisibility has intrigued man for centuries. Highly gifted
 
 ## Changelog
 
+* 0.61.0
+  - IN-2434 Implementação da uma estrutura simples para plugins no backend
+      > Adição do um primeiro plugin:  asgard-api-plugin-metrics-mesos==0.1.0
+
 * 0.60.0
   - Mudança do versionamento para SemVer. Estávamos incrementando o `.patch` e não o `.minor`.
   - IN-2422 Fix no scale após edição da app e que todas as apps eram renovadas

--- a/hollowman/app.py
+++ b/hollowman/app.py
@@ -9,6 +9,7 @@ import newrelic.agent
 
 from flask import request, Blueprint, Response
 from flask_cors import CORS
+import pkg_resources
 
 from hollowman.hollowman_flask import HollowmanFlask
 from hollowman.conf import SECRET_KEY, CORS_WHITELIST, NEW_RELIC_LICENSE_KEY, NEW_RELIC_APP_NAME
@@ -17,6 +18,7 @@ from hollowman.plugins import register_plugin
 from hollowman.auth.jwt import jwt_auth
 from hollowman.metrics.zk.routes import zk_metrics_blueprint
 from hollowman.api.account import account_blueprint
+from hollowman.plugins import load_all_metrics_plugins
 
 
 if NEW_RELIC_LICENSE_KEY and NEW_RELIC_APP_NAME:
@@ -78,4 +80,4 @@ marathon.log = dev_null_logger
 import hollowman.routes
 register_plugin("example-plugin")
 register_plugin("session-checker-plugin")
-
+load_all_metrics_plugins(application)

--- a/hollowman/plugins/__init__.py
+++ b/hollowman/plugins/__init__.py
@@ -52,7 +52,14 @@ def load_all_metrics_plugins(flask_application):
             package_name = entrypoint.dist.project_name
             entrypoint_function = entrypoint.load()
             plugin_data = entrypoint_function()
-            flask_application.register_blueprint(plugin_data['blueprint'], url_prefix=f"/_cat/metrics/{package_name}")
+            url_prefix = f"/_cat/metrics/{package_name}"
+            flask_application.register_blueprint(plugin_data['blueprint'], url_prefix=url_prefix)
+            logger.info({
+                "msg": "Metrics plugin loaded",
+                "plugin_entrypoint": entrypoint,
+                "plugin_id": package_name,
+                "mountpoint URI": url_prefix,
+            })
         except Exception as e:
             logger.error({
                 "msg": "Failed to load plugin",

--- a/hollowman/plugins/__init__.py
+++ b/hollowman/plugins/__init__.py
@@ -1,5 +1,16 @@
 #encoding: utf-8
 
+from enum import Enum
+import traceback
+import sys
+
+import pkg_resources
+
+from hollowman.log import logger
+
+class API_PLUGIN_TYPES(Enum):
+    API_METRIC_PLUGIN = "asgard_api_metrics_mountpoint"
+
 # Registry é um dict onde a key é o ID do plugin e o value
 # são meta-dados sobre o plugin, ex:
 #    * ID do plugin
@@ -30,4 +41,24 @@ def register_plugin(plugin_id):
 
 def get_plugin_registry_data():
     return {'plugins': list(PLUGIN_REGISTRY.values())}
+
+def load_entrypoint_group(groupname):
+    return list(pkg_resources.iter_entry_points(group=groupname))
+
+def load_all_metrics_plugins(flask_application):
+    all_metric_plugins = load_entrypoint_group(API_PLUGIN_TYPES.API_METRIC_PLUGIN.value)
+    for entrypoint in all_metric_plugins:
+        try:
+            package_name = entrypoint.dist.project_name
+            entrypoint_function = entrypoint.load()
+            plugin_data = entrypoint_function()
+            flask_application.register_blueprint(plugin_data['blueprint'], url_prefix=f"/_cat/metrics/{package_name}")
+        except Exception as e:
+            logger.error({
+                "msg": "Failed to load plugin",
+                "plugin_entrypoint": entrypoint,
+                "plugin_id": package_name,
+                "traceback": traceback.format_exc(),
+                "type": sys.exc_info()[0].__name__,
+            })
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,4 @@
 ipdb==0.10.1
+./tests/fixtures/plugins/metrics/metric-plugin-example-1
 -r requirements.txt
 -r requirements-tests.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,4 +11,4 @@ sqlalchemy==1.1.13
 newrelic==2.100.0.84
 
 # Asgard API Plugins
-asgard-api-plugin-metrics-mesos==0.3.0rc1
+asgard-api-plugin-metrics-mesos==0.3.0rc2

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,4 +11,4 @@ sqlalchemy==1.1.13
 newrelic==2.100.0.84
 
 # Asgard API Plugins
-asgard-api-plugin-metrics-mesos==0.1.0
+asgard-api-plugin-metrics-mesos==0.3.0rc1

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,6 @@ requests==2.18.3
 simple-json-logger==0.2.0
 sqlalchemy==1.1.13
 newrelic==2.100.0.84
+
+# Asgard API Plugins
+asgard-api-plugin-metrics-mesos==0.1.0

--- a/tests/fixtures/plugins/metrics/metric-plugin-example-1/metrics/__init__.py
+++ b/tests/fixtures/plugins/metrics/metric-plugin-example-1/metrics/__init__.py
@@ -1,0 +1,25 @@
+
+from flask import Blueprint
+
+my_metrics_blue_print = Blueprint(__name__, __name__)
+
+def plugin_init_ok():
+  return {
+    'blueprint': my_metrics_blue_print
+  }
+
+def plugin_init_wrong_return():
+    return {
+        'blueprint': int(42)
+    }
+
+def plugin_init_exception():
+    return 1/0
+
+@my_metrics_blue_print.route("/ping")
+def some_endpoint():
+    return "Metrics Plugin Example 1 OK"
+
+
+
+

--- a/tests/fixtures/plugins/metrics/metric-plugin-example-1/setup.py
+++ b/tests/fixtures/plugins/metrics/metric-plugin-example-1/setup.py
@@ -1,0 +1,27 @@
+from setuptools import setup, find_packages
+
+setup(
+    name='asgard-api-plugin-metrics-example-1',
+    version='0.1.0',
+
+    description='a plugin to the Asgard API',
+    long_description="Plugin",
+    url='',
+    author='',
+    author_email='',
+    license='MIT',
+    classifiers=[
+        'Programming Language :: Python :: 3.6',
+    ],
+
+    packages=find_packages(exclude=['contrib', 'docs', 'tests*']),
+
+    entry_points={
+        'asgard_api_metrics_mountpoint': [
+            'init_ok = metrics:plugin_init_ok',
+            'init_wrong_blueprint = metrics:plugin_init_wrong_return',
+            'init_non_existant_entrypoint = metrics:does_not_exist',
+            'init_exception_on_load = metrics:plugin_init_exception',
+        ],
+    },
+)

--- a/tests/test_pluginloader.py
+++ b/tests/test_pluginloader.py
@@ -9,14 +9,6 @@ class PluginLoaderTest(unittest.TestCase):
     def setUp(self):
         pass
 
-    def test_plugin_load_all_plugins_from_one_entrypoint_group(self):
-        """
-        Testa que conseguimos carregar todos os Entrypoints de um
-        determinado grupo
-        """
-        plugins = load_entrypoint_group("asgard_api_metrics_mountpoint")
-        self.assertEqual(4, len(plugins))
-
     def test_plugin_load_metrics_plugins(self):
         """
         Plugins do tipo Metric Plugin devem fornecer um objeto do tipo flask.Blueprint.

--- a/tests/test_pluginloader.py
+++ b/tests/test_pluginloader.py
@@ -1,0 +1,36 @@
+
+from hollowman.plugins import load_entrypoint_group, load_all_metrics_plugins
+from hollowman.app import application
+
+import unittest
+
+class PluginLoaderTest(unittest.TestCase):
+
+    def setUp(self):
+        pass
+
+    def test_plugin_load_all_plugins_from_one_entrypoint_group(self):
+        """
+        Testa que conseguimos carregar todos os Entrypoints de um
+        determinado grupo
+        """
+        plugins = load_entrypoint_group("asgard_api_metrics_mountpoint")
+        self.assertEqual(4, len(plugins))
+
+    def test_plugin_load_metrics_plugins(self):
+        """
+        Plugins do tipo Metric Plugin devem fornecer um objeto do tipo flask.Blueprint.
+        Plugins que falharem em fornecer esse objeto não serão carregados
+
+        Aqui temos um plugin, instalado via requirements-dev.txt chamado `asgard-api-plugin-metrics-example-1`
+        esse plugin fornece 4 entrypoints. Apenas um dos entrypoints está 100% correto.
+
+        O que esse teste confere é que quando carregamos esse plugin, apenas um novo endpoint é adicionado à
+        app flask principal
+        """
+        load_all_metrics_plugins(application)
+        with application.test_client() as client:
+            response = client.get("/_cat/metrics/asgard-api-plugin-metrics-example-1/ping")
+            self.assertEqual(200, response.status_code)
+            self.assertEqual(b"Metrics Plugin Example 1 OK", response.data)
+


### PR DESCRIPTION
IN-2422

A ideia é poder ter plugins que são instalados via pip. Esses plugins
poderão adicionar funcionalidades à API de diversas formas e em
diversas áreas diferentes. Basta que a API exponha "pontos de extensão"
para que plugins possam usar.

Essa primeira implementação expõe uma forma de plugins adiconarem novos
endpoints HTTP para coleta de métricas. Todos os entrypoinnts do plugin
estarão disponíveis em `/_cat/metrics/<plugin-id>/*` onde `<plugin-id>`
é o nome do pacote python que forneceu esse plugin.