### PR TITLE
Removendo key `secrets` antes de fazer o upstream request

### DIFF
--- a/hollowman/upstream.py
+++ b/hollowman/upstream.py
@@ -45,4 +45,5 @@ def _make_request(path, method, params=None, headers=None, data=None):
 def _remove_keys(data):
     data.pop("version", None)
     data.pop("fetch", None)
+    data.pop("secrets", None)
 

--- a/tests/test_upstream.py
+++ b/tests/test_upstream.py
@@ -85,12 +85,13 @@ class UpstreamTest(TestCase):
         A API aceita uma lista se o request for um PUT em /v2/apps.
         O pop() da lista se comporta diferente do pop do dict. Temos que tratar isso.
         """
-        with application.test_request_context("/v2/apps", method="PUT", data='[{"id": "/abc", "version": "0", "fetch": ["a", "b"]}]', headers={'Content-Type': 'application/json'}):
+        with application.test_request_context("/v2/apps", method="PUT", data='[{"id": "/abc", "version": "0", "fetch": ["a", "b"], "secrets": {}}]', headers={'Content-Type': 'application/json'}):
             replay_request(flask.request)
             self.assertTrue(mock_put.called)
             called_data_json = json.loads(mock_put.call_args[1]['data'])
             self.assertFalse('version' in called_data_json[0])
             self.assertFalse('fetch' in called_data_json[0])
+            self.assertFalse('secrets' in called_data_json[0])
 
     @patch.object(requests, 'put')
     def test_remove_some_key_before_replay_put_request(self, mock_put):
@@ -101,12 +102,13 @@ class UpstreamTest(TestCase):
         When GETting an app, Marathon returns a JSON with these two keys, bus refuses to
         accept a PUT/POST on this same app if these keys are present.
         """
-        with application.test_request_context("/v2/apps", method="PUT", data='{"id": "/abc", "version": "0", "fetch": ["a", "b"]}', headers={'Content-Type': 'application/json'}):
+        with application.test_request_context("/v2/apps", method="PUT", data='{"id": "/abc", "version": "0", "fetch": ["a", "b"], "secrets": {}}', headers={'Content-Type': 'application/json'}):
             replay_request(flask.request)
             self.assertTrue(mock_put.called)
             called_data_json = json.loads(mock_put.call_args[1]['data'])
             self.assertFalse('version' in called_data_json)
             self.assertFalse('fetch' in called_data_json)
+            self.assertFalse('secrets' in called_data_json)
 
     @patch.object(requests, 'post')
     def test_remove_some_key_before_replay_post_request(self, mock_post):
@@ -117,36 +119,23 @@ class UpstreamTest(TestCase):
         When GETting an app, Marathon returns a JSON with these two keys, bus refuses to
         accept a PUT/POST on this same app if these keys are present.
         """
-        with application.test_request_context("/v2/apps", method="POST", data='{"id": "/abc", "version": "0", "fetch": ["a", "b"]}', headers={'Content-Type': 'application/json'}):
+        with application.test_request_context("/v2/apps", method="POST", data='{"id": "/abc", "version": "0", "fetch": ["a", "b"], "secrets": {}}', headers={'Content-Type': 'application/json'}):
             #flask.request.is_json = True
             replay_request(flask.request)
             self.assertTrue(mock_post.called)
             called_data_json = json.loads(mock_post.call_args[1]['data'])
             self.assertFalse('version' in called_data_json)
             self.assertFalse('fetch' in called_data_json)
+            self.assertFalse('secrets' in called_data_json)
 
     @patch.object(requests, 'post')
     def test_no_not_attempt_to_parse_a_non_json_body_post(self, mock_post):
-        """
-        We must remove these keys:
-            * version
-            * fetch
-        When GETting an app, Marathon returns a JSON with these two keys, bus refuses to
-        accept a PUT/POST on this same app if these keys are present.
-        """
         with application.test_request_context("/v2/apps//foo/bar/restart", method="POST", data=''):
             replay_request(flask.request)
             self.assertTrue(mock_post.called)
 
     @patch.object(requests, 'put')
     def test_no_not_attempt_to_parse_a_non_json_body_put(self, mock_put):
-        """
-        We must remove these keys:
-            * version
-            * fetch
-        When GETting an app, Marathon returns a JSON with these two keys, bus refuses to
-        accept a PUT/POST on this same app if these keys are present.
-        """
         with application.test_request_context("/v2/apps//foo/bar/restart", method="PUT", data=''):
             replay_request(flask.request)
             self.assertTrue(mock_put.called)


### PR DESCRIPTION
O marathon retorna uma key `secrets` no JSON das apps mesmo quando essa
feature está *desligada*. Só que quando essa feature está desligada o
próprio marathon *recusa* PUT/POST de JSONs que mencionam essa key,
o que faz com que a asgard API pare de funcionar, já que todas as
apps buscadas no Marathon vão conter essa key.

Mais detalhes: https://jira.mesosphere.com/browse/MARATHON-8226

O preço disso é não podermos usar a feature de secrets, mas se um dia
ligarmos essa feature, poderemos remover esse commit e deixar a key
passar livremente.