### PR TITLE
Adicionando timeout em 3s nas chamadas ao Marathon

### DIFF
--- a/hollowman/upstream.py
+++ b/hollowman/upstream.py
@@ -45,10 +45,15 @@ def _make_request(path, method, params=None, headers=None, data=None):
             )
             conf.MARATHON_LEADER = leader_addr
             logger.debug(
-                {"new_leader": conf.MARATHON_LEADER, "talked_to": marathon_backend}
+                {
+                    "new_leader": conf.MARATHON_LEADER,
+                    "talked_to": marathon_backend,
+                }
             )
             return response
         except requests.exceptions.ConnectionError as e:
+            pass
+        except requests.exceptions.ReadTimeout as timeout:
             pass
     raise Exception("No Marathon servers found")
 

--- a/hollowman/upstream.py
+++ b/hollowman/upstream.py
@@ -38,7 +38,7 @@ def _make_request(path, method, params=None, headers=None, data=None):
         try:
             url = "{}{}".format(marathon_backend, path)
             response = getattr(requests, method)(
-                url, params=params, headers=headers, data=data, timeout=3
+                url, params=params, headers=headers, data=data, timeout=(1, 5)
             )
             leader_addr = response.headers.pop(
                 "X-Marathon-Leader", conf.MARATHON_ADDRESSES[0]

--- a/hollowman/upstream.py
+++ b/hollowman/upstream.py
@@ -38,17 +38,14 @@ def _make_request(path, method, params=None, headers=None, data=None):
         try:
             url = "{}{}".format(marathon_backend, path)
             response = getattr(requests, method)(
-                url, params=params, headers=headers, data=data
+                url, params=params, headers=headers, data=data, timeout=3
             )
             leader_addr = response.headers.pop(
                 "X-Marathon-Leader", conf.MARATHON_ADDRESSES[0]
             )
             conf.MARATHON_LEADER = leader_addr
             logger.debug(
-                {
-                    "new_leader": conf.MARATHON_LEADER,
-                    "talked_to": marathon_backend,
-                }
+                {"new_leader": conf.MARATHON_LEADER, "talked_to": marathon_backend}
             )
             return response
         except requests.exceptions.ConnectionError as e:


### PR DESCRIPTION
Segundo a doc do requests esse timeout não é do request todo e sim
da frequência de de transferencias de dados na rede.

http://docs.python-requests.org/en/master/user/quickstart/#timeouts