### PR TITLE
Removendo chamada desnecessária à API do Marathon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+### 0.81.0
+ * Removidas chamadas desnecessárias à API do Marathon nos requests GET /v2/apps e GET /v2/groups
+
 ### 0.80.0
  * Adicionando ConnectTimeout nos requests para o Marathon (python síncrono)
  * Implementação dos endpoints `/agents/*`

--- a/hollowman/http_wrappers/request.py
+++ b/hollowman/http_wrappers/request.py
@@ -83,7 +83,11 @@ class Request(HTTPWrapper):
 
         if self.is_read_request():
             if self.is_list_apps_request():
-                apps = self.marathon_client.list_apps()
+                apps = list(
+                    self._get_original_group(
+                        self.request.user, self.object_id
+                    ).iterate_apps()
+                )
                 for app in apps:
                     yield self.merge_marathon_apps(MarathonApp(), app), app
             elif self.is_app_request():

--- a/hollowman/http_wrappers/response.py
+++ b/hollowman/http_wrappers/response.py
@@ -28,12 +28,11 @@ class Response(HTTPWrapper):
         if self.is_read_request():
             response_content = json.loads(self.response.data)
             if self.is_list_apps_request():
-                for app in response_content["apps"]:
-                    response_app = AsgardApp.from_json(app)
-                    app = self.marathon_client.get_app(
-                        self.object_id or response_app.id
-                    )
-                    yield response_app, app
+                all_apps = list(
+                    AsgardAppGroup.from_json(response_content).iterate_apps()
+                )
+                for response_app in all_apps:
+                    yield response_app, response_app
                 return
             elif self.is_group_request():
                 response_group = AsgardAppGroup(

--- a/hollowman/http_wrappers/response.py
+++ b/hollowman/http_wrappers/response.py
@@ -39,14 +39,7 @@ class Response(HTTPWrapper):
                     MarathonGroup.from_json(response_content)
                 )
                 for current_group in response_group.iterate_groups():
-                    group_id = current_group.id
-                    group_id_without_namespace = self._remove_namespace_if_exists(
-                        self.request.user.current_account.namespace, group_id
-                    )
-                    original_group = self._get_original_group(
-                        self.request.user, group_id_without_namespace
-                    )
-                    yield current_group, original_group
+                    yield current_group, current_group
                 return
             elif self.is_tasks_request():
                 for task in response_content["tasks"]:

--- a/tests/http_wrappers/test_request.py
+++ b/tests/http_wrappers/test_request.py
@@ -66,7 +66,7 @@ class SplitTests(TestCase):
             with RequestsMock() as rsps:
                 rsps.add(
                     method="GET",
-                    url=conf.MARATHON_ADDRESSES[0] + "/v2/apps",
+                    url=conf.MARATHON_ADDRESSES[0] + "/v2/groups//dev/",
                     body=json.dumps(fixture),
                     status=200,
                 )
@@ -595,9 +595,9 @@ class JoinTests(TestCase):
             with RequestsMock() as rsps:
                 rsps.add(
                     method="GET",
-                    url=conf.MARATHON_ADDRESSES[0] + "/v2/apps",
+                    url=conf.MARATHON_ADDRESSES[0] + "/v2/groups//dev/",
                     status=200,
-                    body="""{"apps":[]}""",
+                    body=json.dumps({"apps": []}),
                 )
                 apps = list(request.split())
                 joined_request = request.join(apps)

--- a/tests/http_wrappers/test_response.py
+++ b/tests/http_wrappers/test_response.py
@@ -100,9 +100,6 @@ class SplitTests(unittest.TestCase):
             original_apps = [MarathonApp.from_json(app) for app in apps]
             client.get_app.side_effect = original_apps
             apps = list(response.split())
-            self.assertEqual(
-                [call("/foo"), call("/xablau")], client.get_app.call_args_list
-            )
 
         self.assertEqual(
             apps,

--- a/tests/http_wrappers/test_response.py
+++ b/tests/http_wrappers/test_response.py
@@ -136,63 +136,19 @@ class SplitTests(unittest.TestCase):
                 status=HTTPStatus.OK,
                 headers={},
             )
-            with RequestsMock() as rsps:
-                rsps.add(
-                    method="GET",
-                    url=conf.MARATHON_ADDRESSES[0] + "/v2/groups//dev/",
-                    body=json.dumps(deepcopy(group_dev_namespace_fixture)),
-                    status=200,
-                )
-                rsps.add(
-                    method="GET",
-                    url=conf.MARATHON_ADDRESSES[0] + "/v2/groups//dev/a",
-                    body=json.dumps(
-                        deepcopy(group_dev_namespace_fixture["groups"][0])
-                    ),
-                    status=200,
-                )
-                rsps.add(
-                    method="GET",
-                    url=conf.MARATHON_ADDRESSES[0] + "/v2/groups//dev/group-b",
-                    body=json.dumps(
-                        deepcopy(group_dev_namespace_fixture["groups"][1])
-                    ),
-                    status=200,
-                )
-                rsps.add(
-                    method="GET",
-                    url=conf.MARATHON_ADDRESSES[0]
-                    + "/v2/groups//dev/group-b/group-b0",
-                    body=json.dumps(
-                        deepcopy(
-                            group_dev_namespace_fixture["groups"][1]["groups"][
-                                0
-                            ]
-                        )
-                    ),
-                    status=200,
-                )
-                rsps.add(
-                    method="GET",
-                    url=conf.MARATHON_ADDRESSES[0] + "/v2/groups//dev/group-c",
-                    body=json.dumps(
-                        deepcopy(group_dev_namespace_fixture["groups"][2])
-                    ),
-                    status=200,
-                )
 
-                ctx.request.user = self.user
-                response = Response(ctx.request, response)
-                groups_tuple = list(response.split())
-                self.assertEqual(5, len(groups_tuple))
-                expected_groups = [
-                    AsgardAppGroup(g)
-                    for g in AsgardAppGroup(
-                        MarathonGroup.from_json(group_dev_namespace_fixture)
-                    ).iterate_groups()
-                ]
-                # Compara com os groups originais
-                self.assertEqual(expected_groups, [g[1] for g in groups_tuple])
+            ctx.request.user = self.user
+            response = Response(ctx.request, response)
+            groups_tuple = list(response.split())
+            self.assertEqual(5, len(groups_tuple))
+            expected_groups = [
+                AsgardAppGroup(g)
+                for g in AsgardAppGroup(
+                    MarathonGroup.from_json(group_dev_namespace_fixture)
+                ).iterate_groups()
+            ]
+            # Compara com os groups originais
+            self.assertEqual(expected_groups, [g[1] for g in groups_tuple])
 
     @with_json_fixture("../fixtures/group_dev_namespace_with_apps.json")
     def test_split_group_nonroot_empty_group(self, group_dev_namespace_fixture):
@@ -204,30 +160,21 @@ class SplitTests(unittest.TestCase):
                 status=HTTPStatus.OK,
                 headers={},
             )
-            with RequestsMock() as rsps:
-                rsps.add(
-                    method="GET",
-                    url=conf.MARATHON_ADDRESSES[0] + "/v2/groups//dev/group-c",
-                    body=json.dumps(
-                        deepcopy(group_dev_namespace_fixture["groups"][2])
-                    ),
-                    status=200,
-                )
 
-                ctx.request.user = self.user
-                response = Response(ctx.request, response)
-                groups_tuple = list(response.split())
-                self.assertEqual(1, len(groups_tuple))
-                expected_groups = [
-                    AsgardAppGroup(g)
-                    for g in AsgardAppGroup(
-                        MarathonGroup.from_json(
-                            group_dev_namespace_fixture["groups"][2]
-                        )
-                    ).iterate_groups()
-                ]
-                # Compara com os groups originais
-                self.assertEqual(expected_groups, [g[1] for g in groups_tuple])
+            ctx.request.user = self.user
+            response = Response(ctx.request, response)
+            groups_tuple = list(response.split())
+            self.assertEqual(1, len(groups_tuple))
+            expected_groups = [
+                AsgardAppGroup(g)
+                for g in AsgardAppGroup(
+                    MarathonGroup.from_json(
+                        group_dev_namespace_fixture["groups"][2]
+                    )
+                ).iterate_groups()
+            ]
+            # Compara com os groups originais
+            self.assertEqual(expected_groups, [g[1] for g in groups_tuple])
 
     @unittest.skip("A ser implementado")
     def test_split_groups_write_PUT_on_group(self):
@@ -245,43 +192,20 @@ class SplitTests(unittest.TestCase):
                 status=HTTPStatus.OK,
                 headers={},
             )
-            with RequestsMock() as rsps:
-                rsps.add(
-                    method="GET",
-                    url=conf.MARATHON_ADDRESSES[0] + "/v2/groups//dev/group-b",
-                    body=json.dumps(
-                        deepcopy(group_dev_namespace_fixture["groups"][1])
-                    ),
-                    status=200,
-                )
-                rsps.add(
-                    method="GET",
-                    url=conf.MARATHON_ADDRESSES[0]
-                    + "/v2/groups//dev/group-b/group-b0",
-                    body=json.dumps(
-                        deepcopy(
-                            group_dev_namespace_fixture["groups"][1]["groups"][
-                                0
-                            ]
-                        )
-                    ),
-                    status=200,
-                )
-
-                ctx.request.user = self.user
-                response = Response(ctx.request, response)
-                groups_tuple = list(response.split())
-                self.assertEqual(2, len(groups_tuple))
-                expected_groups = [
-                    AsgardAppGroup(g)
-                    for g in AsgardAppGroup(
-                        MarathonGroup.from_json(
-                            group_dev_namespace_fixture["groups"][1]
-                        )
-                    ).iterate_groups()
-                ]
-                # Compara com os groups originais
-                self.assertEqual(expected_groups, [g[1] for g in groups_tuple])
+            ctx.request.user = self.user
+            response = Response(ctx.request, response)
+            groups_tuple = list(response.split())
+            self.assertEqual(2, len(groups_tuple))
+            expected_groups = [
+                AsgardAppGroup(g)
+                for g in AsgardAppGroup(
+                    MarathonGroup.from_json(
+                        group_dev_namespace_fixture["groups"][1]
+                    )
+                ).iterate_groups()
+            ]
+            # Compara com os groups originais
+            self.assertEqual(expected_groups, [g[1] for g in groups_tuple])
 
     @with_json_fixture("../fixtures/tasks/get.json")
     def test_split_tasks_GET(self, tasks_get_fixture):
@@ -500,42 +424,24 @@ class JoinTests(unittest.TestCase):
                 status=HTTPStatus.OK,
                 headers={},
             )
-            with RequestsMock() as rsps:
-                rsps.add(
-                    method="GET",
-                    url=conf.MARATHON_ADDRESSES[0] + "/v2/groups//dev/",
-                    body=json.dumps(deepcopy(group_dev_namespace_fixture)),
-                    status=200,
-                )
-                rsps.add(
-                    method="GET",
-                    url=conf.MARATHON_ADDRESSES[0] + "/v2/groups//dev/group-b",
-                    body=json.dumps(
-                        deepcopy(group_dev_namespace_fixture["groups"][0])
-                    ),
-                    status=200,
-                )
 
-                ctx.request.user = self.user
-                response = Response(ctx.request, response)
-                groups_tuple = list(response.split())
-                joined_response = response.join(groups_tuple)
+            ctx.request.user = self.user
+            response = Response(ctx.request, response)
+            groups_tuple = list(response.split())
+            joined_response = response.join(groups_tuple)
 
-                joined_response_data = json.loads(joined_response.data)
-                self.assertEqual("/dev", joined_response_data["id"])
-                self.assertEqual(
-                    "/dev/group-b", joined_response_data["groups"][0]["id"]
-                )
-                self.assertEqual(
-                    [], joined_response_data["dependencies"]
-                )  # Groups should be reendered in full
-                self.assertEqual(
-                    1, len(joined_response_data["groups"][0]["apps"])
-                )
-                self.assertEqual(
-                    [],
-                    joined_response_data["groups"][0]["apps"][0]["constraints"],
-                )  # Apps should also be renderen in full
+            joined_response_data = json.loads(joined_response.data)
+            self.assertEqual("/dev", joined_response_data["id"])
+            self.assertEqual(
+                "/dev/group-b", joined_response_data["groups"][0]["id"]
+            )
+            self.assertEqual(
+                [], joined_response_data["dependencies"]
+            )  # Groups should be reendered in full
+            self.assertEqual(1, len(joined_response_data["groups"][0]["apps"]))
+            self.assertEqual(
+                [], joined_response_data["groups"][0]["apps"][0]["constraints"]
+            )  # Apps should also be renderen in full
 
     @with_json_fixture("../fixtures/tasks/get_single_namespace.json")
     def test_join_tasks_GET(self, tasks_single_namespace_fixture):

--- a/tests/routes/test_apiv2.py
+++ b/tests/routes/test_apiv2.py
@@ -75,8 +75,9 @@ class TestAuthentication(TestCase):
                 )
                 rsps.add(
                     method="GET",
-                    url=conf.MARATHON_ADDRESSES[0] + "/v2/apps//foo",
-                    body=json.dumps({"app": fixture}),
+                    url=conf.MARATHON_ADDRESSES[0]
+                    + f"/v2/groups//{self.normal_user.accounts[0].namespace}/",
+                    body=json.dumps({"apps": [fixture]}),
                     status=200,
                 )
                 r = test_client.get("/v2/apps", headers=auth_header)

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -65,6 +65,18 @@ class TestAuthentication(TestCase):
         )
         responses.add(
             method="GET",
+            url=conf.MARATHON_ADDRESSES[0] + "/v2/groups//dev/",
+            body=json.dumps({"apps": [fixture]}),
+            status=200,
+        )
+        responses.add(
+            method="GET",
+            url=conf.MARATHON_ADDRESSES[0] + "/v2/groups//infra/",
+            body=json.dumps({"apps": [fixture]}),
+            status=200,
+        )
+        responses.add(
+            method="GET",
             url=conf.MARATHON_ADDRESSES[0] + "/v2/apps//foo",
             body=json.dumps({"app": fixture}),
             status=200,

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -59,42 +59,21 @@ class ResponsePipelineTest(unittest.TestCase):
                 status=HTTPStatus.OK,
                 headers={},
             )
-            with RequestsMock() as rsps:
-                rsps.add(
-                    method="GET",
-                    url=conf.MARATHON_ADDRESSES[0] + "/v2/groups//dev/group-b",
-                    body=json.dumps(
-                        deepcopy(group_dev_namespace_fixture["groups"][1])
-                    ),
-                    status=200,
-                )
-                rsps.add(
-                    method="GET",
-                    url=conf.MARATHON_ADDRESSES[0]
-                    + "/v2/groups//dev/group-b/group-b0",
-                    body=json.dumps(
-                        deepcopy(
-                            group_dev_namespace_fixture["groups"][1]["groups"][
-                                0
-                            ]
-                        )
-                    ),
-                    status=200,
-                )
 
-                response_wrapper = Response(ctx.request, ok_response)
-                final_response = dispatch(
-                    user=self.user,
-                    request=response_wrapper,
-                    filters_pipeline={OperationType.READ: [DummyFilter()]},
-                    filter_method_name_callback=lambda *args: "response_group",
-                )
-                final_response_data = json.loads(final_response.data)
-                returned_group = MarathonGroup.from_json(final_response_data)
-                self.assertEqual("/dummy/dev/group-b", returned_group.id)
-                self.assertEqual(
-                    "/dummy/dev/group-b/group-b0", returned_group.groups[0].id
-                )
+            response_wrapper = Response(ctx.request, ok_response)
+            final_response = dispatch(
+                user=self.user,
+                request=response_wrapper,
+                filters_pipeline={OperationType.READ: [DummyFilter()]},
+                filter_method_name_callback=lambda *args: "response_group",
+            )
+            final_response_data = json.loads(final_response.data)
+            returned_group = MarathonGroup.from_json(final_response_data)
+
+            self.assertEqual("/dummy/dev/group-b", returned_group.id)
+            self.assertEqual(
+                "/dummy/dev/group-b/group-b0", returned_group.groups[0].id
+            )
 
     @with_json_fixture("../fixtures/group_dev_namespace_with_apps.json")
     def test_filters_can_modify_all_apps_from_group_and_subgroups(
@@ -112,45 +91,23 @@ class ResponsePipelineTest(unittest.TestCase):
                 status=HTTPStatus.OK,
                 headers={},
             )
-            with RequestsMock() as rsps:
-                rsps.add(
-                    method="GET",
-                    url=conf.MARATHON_ADDRESSES[0] + "/v2/groups//dev/group-b",
-                    body=json.dumps(
-                        deepcopy(group_dev_namespace_fixture["groups"][1])
-                    ),
-                    status=200,
-                )
-                rsps.add(
-                    method="GET",
-                    url=conf.MARATHON_ADDRESSES[0]
-                    + "/v2/groups//dev/group-b/group-b0",
-                    body=json.dumps(
-                        deepcopy(
-                            group_dev_namespace_fixture["groups"][1]["groups"][
-                                0
-                            ]
-                        )
-                    ),
-                    status=200,
-                )
 
-                response_wrapper = Response(ctx.request, ok_response)
-                final_response = dispatch(
-                    user=self.user,
-                    request=response_wrapper,
-                    filters_pipeline={OperationType.READ: [DummyFilter()]},
-                    filter_method_name_callback=lambda *args: "response_group",
-                )
-                final_response_data = json.loads(final_response.data)
-                returned_group = MarathonGroup.from_json(final_response_data)
-                self.assertEqual(
-                    "/dummy/dev/group-b/appb0", returned_group.apps[0].id
-                )
-                self.assertEqual(
-                    "/dummy/dev/group-b/group-b0/app0",
-                    returned_group.groups[0].apps[0].id,
-                )
+            response_wrapper = Response(ctx.request, ok_response)
+            final_response = dispatch(
+                user=self.user,
+                request=response_wrapper,
+                filters_pipeline={OperationType.READ: [DummyFilter()]},
+                filter_method_name_callback=lambda *args: "response_group",
+            )
+            final_response_data = json.loads(final_response.data)
+            returned_group = MarathonGroup.from_json(final_response_data)
+            self.assertEqual(
+                "/dummy/dev/group-b/appb0", returned_group.apps[0].id
+            )
+            self.assertEqual(
+                "/dummy/dev/group-b/group-b0/app0",
+                returned_group.groups[0].apps[0].id,
+            )
 
     @with_json_fixture("../fixtures/group_dev_namespace_with_apps.json")
     def test_changes_from_all_filters_are_persisted_after_response_join(
@@ -170,48 +127,26 @@ class ResponsePipelineTest(unittest.TestCase):
                 status=HTTPStatus.OK,
                 headers={},
             )
-            with RequestsMock() as rsps:
-                rsps.add(
-                    method="GET",
-                    url=conf.MARATHON_ADDRESSES[0] + "/v2/groups//dev/group-b",
-                    body=json.dumps(
-                        deepcopy(group_dev_namespace_fixture["groups"][1])
-                    ),
-                    status=200,
-                )
-                rsps.add(
-                    method="GET",
-                    url=conf.MARATHON_ADDRESSES[0]
-                    + "/v2/groups//dev/group-b/group-b0",
-                    body=json.dumps(
-                        deepcopy(
-                            group_dev_namespace_fixture["groups"][1]["groups"][
-                                0
-                            ]
-                        )
-                    ),
-                    status=200,
-                )
 
-                ctx.request.user = self.user
-                response_wrapper = Response(ctx.request, ok_response)
-                final_response = dispatch(
-                    user=self.user,
-                    request=response_wrapper,
-                    filters_pipeline={
-                        OperationType.READ: [DummyFilter(), FooFilter()]
-                    },
-                    filter_method_name_callback=lambda *args: "response_group",
-                )
-                final_response_data = json.loads(final_response.data)
-                returned_group = MarathonGroup.from_json(final_response_data)
-                self.assertEqual(
-                    "/foo/dummy/dev/group-b/appb0", returned_group.apps[0].id
-                )
-                self.assertEqual(
-                    "/foo/dummy/dev/group-b/group-b0/app0",
-                    returned_group.groups[0].apps[0].id,
-                )
+            ctx.request.user = self.user
+            response_wrapper = Response(ctx.request, ok_response)
+            final_response = dispatch(
+                user=self.user,
+                request=response_wrapper,
+                filters_pipeline={
+                    OperationType.READ: [DummyFilter(), FooFilter()]
+                },
+                filter_method_name_callback=lambda *args: "response_group",
+            )
+            final_response_data = json.loads(final_response.data)
+            returned_group = MarathonGroup.from_json(final_response_data)
+            self.assertEqual(
+                "/foo/dummy/dev/group-b/appb0", returned_group.apps[0].id
+            )
+            self.assertEqual(
+                "/foo/dummy/dev/group-b/group-b0/app0",
+                returned_group.groups[0].apps[0].id,
+            )
 
     @unittest.skip(
         "Temos que decidir se vamos retornar o group com minimal=True ou False"

--- a/tests/test_request_handlers.py
+++ b/tests/test_request_handlers.py
@@ -217,6 +217,12 @@ class RequestHandlersTests(TestCase):
             with RequestsMock() as rsps:
                 rsps.add(
                     method="GET",
+                    url=conf.MARATHON_ADDRESSES[0] + "/v2/groups//dev/",
+                    body=json.dumps({"apps": []}),
+                    status=200,
+                )
+                rsps.add(
+                    method="GET",
                     url=conf.MARATHON_ADDRESSES[0] + "/v2/apps",
                     body=json.dumps({"apps": []}),
                     status=200,

--- a/tests/test_request_handlers.py
+++ b/tests/test_request_handlers.py
@@ -163,19 +163,6 @@ class RequestHandlersTests(TestCase):
                     ),
                     status=200,
                 )
-                rsps.add(
-                    method="GET",
-                    url=conf.MARATHON_ADDRESSES[0]
-                    + "/v2/groups//dev/group-b/group-b0",
-                    body=json.dumps(
-                        deepcopy(
-                            group_dev_namespace_fixture["groups"][1]["groups"][
-                                0
-                            ]
-                        )
-                    ),
-                    status=200,
-                )
                 response = client.get("/v2/groups/group-b", headers=auth_header)
                 self.assertEqual(200, response.status_code)
                 self.assertEqual("/group-b", json.loads(response.data)["id"])


### PR DESCRIPTION
Um request GET /v2/apps, autenticado em uma conta qualquer acabava
disparando um GET /v2/apps/{app_id} para **cada app do cluster
interiro**, não só da conta autenticada no request inicial.