### PR TITLE
Adicionando "truncated" na resposta de leitura dos logs de uma task

### DIFF
--- a/asgard/conf.py
+++ b/asgard/conf.py
@@ -15,3 +15,6 @@ ASGARD_HTTP_CLIENT_TOTAL_TIMEOUT = int(
 # Configs que foram migradas do pacote `hollowman.conf`.
 # Depois vamos mudar o prefixo de `HOLLOWMAN_` para `ASGARD_`
 SECRET_KEY = os.getenv("HOLLOWMAN_SECRET_KEY", "secret")
+TASK_FILEREAD_MAX_OFFSET: int = int(
+    os.getenv("ASGARD_TASK_FILEREAD_MAX_OFFSET", 52_428_800)
+)

--- a/hollowman/conf.py
+++ b/hollowman/conf.py
@@ -1,8 +1,10 @@
-import os
 import base64
+import os
 
-from marathon import MarathonClient
+# As configs estão, aos poucos, sendo migradas para o pacote `asgard.conf`
+from asgard.conf import SECRET_KEY, TASK_FILEREAD_MAX_OFFSET
 from asgard.options import get_option
+from marathon import MarathonClient
 
 ENABLED = "1"
 DISABLED = "0"
@@ -81,7 +83,3 @@ LOGLEVEL = os.getenv("ASGARD_LOGLEVEL", "INFO")
 ASGARD_CACHE_KEY_PREFIX = os.getenv("ASGARD_CACHE_KEY_PREFIX", "asgard/")
 ASGARD_CACHE_DEFAULT_TIMEOUT = os.getenv("ASGARD_CACHE_DEFAULT_TIMEOUT", 60)
 ASGARD_CACHE_URL = os.getenv("ASGARD_CACHE_URL", "redis://127.0.0.1:6379/0")
-
-
-# As configs estão, aos poucos, sendo migradas para o pacote `asgard.conf`
-from asgard.conf import SECRET_KEY

--- a/tests/api/test_tasks.py
+++ b/tests/api/test_tasks.py
@@ -1,16 +1,14 @@
-import unittest
 import json
+import unittest
 from http import HTTPStatus
 
 from responses import RequestsMock
-
-from hollowman.conf import DEFAULT_MESOS_ADDRESS
-from hollowman.app import application
-from hollowman import cache
-from hollowman import api
-
 from tests.base import BaseApiTests
-from tests.utils import with_json_fixture, get_raw_fixture
+from tests.utils import get_raw_fixture, with_json_fixture
+
+from hollowman import api, cache
+from hollowman.app import application
+from hollowman.conf import DEFAULT_MESOS_ADDRESS
 
 
 class TasksEndpointTest(BaseApiTests, unittest.TestCase):
@@ -226,6 +224,81 @@ class TasksEndpointTest(BaseApiTests, unittest.TestCase):
                 resp_data = json.loads(resp.data)
                 self.assertEquals(200, resp.status_code)
                 self.assertEquals(0, resp_data["offset"])
+                self.assertFalse(resp_data["truncated"])
+                self.assertEqual(
+                    "*** Starting uWSGI 2.0.14 (64bit) on [Wed Jan 31 19:58:13 2018] ***",
+                    resp_data["data"],
+                )
+
+    @with_json_fixture("../fixtures/api/tasks/task_file_read_response.json")
+    @with_json_fixture(
+        "../fixtures/api/tasks/task_info_namespace_dev_task_id_infra_mongodb_mongodb1.2580925d-0129-11e8-9a03-6e85ded2ca1e.json"
+    )
+    @with_json_fixture(
+        "../fixtures/api/tasks/one_slave_json_id_2084863b-12d1-4319-b515-992eab91a53d-S1.json"
+    )
+    @with_json_fixture(
+        "../fixtures/api/tasks/slave_state_id_2084863b-12d1-4319-b515-992eab91a53d-S1.json"
+    )
+    def test_tasks_read_file_offset_truncated_log_file(
+        self,
+        task_file_read_fixture,
+        one_task_json_fixture,
+        one_slave_json_fixture,
+        slave_state_fixture,
+    ):
+        """
+        Confirma que, quando o offset + length > ${HOLLOWMAN_TASK_FILEREAD_MAX_OFFSET}
+        Por padrão esse offset máximo é de 50MB (52428800)
+        """
+        slave_id = "31fcae61-51a9-4ad1-8054-538503eb53a9-S5"
+        task_id = "infra_mongodb_mongodb1.2580925d-0129-11e8-9a03-6e85ded2ca1e"
+        sandbox_directory = "/tmp/mesos/slaves/31fcae61-51a9-4ad1-8054-538503eb53a9-S5/frameworks/27b52920-3899-4b90-a1d6-bf83a87f3612-0000/executors/dev_infra_mongodb_mongodb1.2580925d-0129-11e8-9a03-6e85ded2ca1e/runs/1ec0d0bf-0f11-49ba-8a03-2cf954ad1cfe"
+        with application.test_client() as client:
+            with RequestsMock() as rsps:
+                rsps.add(
+                    method="GET",
+                    url=f"{DEFAULT_MESOS_ADDRESS}/tasks?task_id={self.user.current_account.namespace}_{task_id}",
+                    body=json.dumps(one_task_json_fixture),
+                    status=200,
+                    match_querystring=True,
+                )
+                rsps.add(
+                    method="GET",
+                    url=f"{DEFAULT_MESOS_ADDRESS}/slaves?slave_id={slave_id}",
+                    body=json.dumps(one_slave_json_fixture),
+                    status=200,
+                    match_querystring=True,
+                )
+                rsps.add(
+                    method="GET",
+                    url="http://127.0.0.1:5051/state",
+                    body=json.dumps(slave_state_fixture),
+                    status=200,
+                )
+                rsps.add(
+                    method="GET",
+                    url=f"http://127.0.0.1:5051/files/read?path={sandbox_directory}/stderr&offset=52428000&length=1024",
+                    body=json.dumps(task_file_read_fixture),
+                    status=200,
+                    match_querystring=True,
+                )
+                rsps.add(
+                    method="GET",
+                    url=f"http://127.0.0.1:5051/files/read?path={sandbox_directory}/stderr&offset=-1",
+                    body=json.dumps({"data": "", "offset": 540}),
+                    status=200,
+                    match_querystring=True,
+                )
+                resp = client.get(
+                    f"/tasks/{task_id}/files/read?path=/stderr&offset=52428000&length=1024",
+                    headers=self.auth_header,
+                )
+
+                resp_data = json.loads(resp.data)
+                self.assertEquals(200, resp.status_code)
+                self.assertEquals(540, resp_data["offset"])
+                self.assertTrue(resp_data["truncated"])
                 self.assertEqual(
                     "*** Starting uWSGI 2.0.14 (64bit) on [Wed Jan 31 19:58:13 2018] ***",
                     resp_data["data"],

--- a/tests/asgard/conf/test_conf.py
+++ b/tests/asgard/conf/test_conf.py
@@ -1,8 +1,8 @@
-import asynctest
 import os
-from asynctest import mock
 from importlib import reload
 
+import asynctest
+from asynctest import mock
 
 from asgard import conf
 
@@ -22,3 +22,14 @@ class AsgardConfTest(asynctest.TestCase):
         reload(conf)
         self.assertEqual(conf.ASGARD_HTTP_CLIENT_CONNECT_TIMEOUT, 1)
         self.assertEqual(conf.ASGARD_HTTP_CLIENT_TOTAL_TIMEOUT, 30)
+
+    async def test_default_task_fileread_max_length(self):
+        reload(conf)
+        self.assertEqual(conf.TASK_FILEREAD_MAX_OFFSET, 52_428_800)
+
+    async def test_task_fileread_max_length_is_converted_to_int(self):
+        with mock.patch.dict(
+            os.environ, ASGARD_TASK_FILEREAD_MAX_OFFSET="1024"
+        ):
+            reload(conf)
+        self.assertEqual(conf.TASK_FILEREAD_MAX_OFFSET, 1024)


### PR DESCRIPTION
Quando o arquivo de log de um atask que está sendo lido foi truncado
indicamos isso no campo `truncated=True` e o campo `offset` já traz o novo
offset do arquivo de log.