### PR TITLE
Testes passando no python 3.7

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -35,7 +35,7 @@ ipdb = "==0.11"
 pytest-cov = "==2.4.0"
 coverage = "==4.2"
 mock = "==2.0.0"
-pytest = "==3.0.1"
+pytest = "==4.4.0"
 responses = "==0.7.0"
 codecov = "*"
 asgard-api = {editable = true,path = "."}

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -157,6 +157,14 @@
             ],
             "version": "==2.2.1"
         },
+        "dataclasses": {
+            "hashes": [
+                "sha256:454a69d788c7fda44efd71e259be79577822f5e3f53f029a22d08004e951dc9f",
+                "sha256:6988bd2b895eef432d562370bb707d540f32f7360ab13da45340101bc2307d84"
+            ],
+            "markers": "python_version < '3.7'",
+            "version": "==0.6"
+        },
         "easyqueue": {
             "hashes": [
                 "sha256:d287e911d34eae3c3c0a8d2548a6199c9fa88697183f02cdaff27c57b53dd31b"
@@ -242,6 +250,13 @@
                 "sha256:cc19709fd6d0cbfed39ea875d29ba6d4e22c0cebc510a76d6302a28385e8bb70"
             ],
             "version": "==2.5"
+        },
+        "idna-ssl": {
+            "hashes": [
+                "sha256:a933e3bb13da54383f9e8f35dc4f9cb9eb9b3b78c6b36f311254d6d0d92c6c7c"
+            ],
+            "markers": "python_version < '3.7'",
+            "version": "==1.1.0"
         },
         "itsdangerous": {
             "hashes": [
@@ -701,6 +716,13 @@
             ],
             "version": "==2.5"
         },
+        "idna-ssl": {
+            "hashes": [
+                "sha256:a933e3bb13da54383f9e8f35dc4f9cb9eb9b3b78c6b36f311254d6d0d92c6c7c"
+            ],
+            "markers": "python_version < '3.7'",
+            "version": "==1.1.0"
+        },
         "imagesize": {
             "hashes": [
                 "sha256:3f349de3eb99145973fefb7dbe38554414e5c30abd0c8e4b970a7c9d09f3a1d8",
@@ -1087,6 +1109,15 @@
                 "sha256:fa4eafaa57074958f065c2a6222d8f11162739f8c9db125472a1f04794a0b91d"
             ],
             "version": "==1.1.2"
+        },
+        "typing-extensions": {
+            "hashes": [
+                "sha256:07b2c978670896022a43c4b915df8958bec4a6b84add7f2c87b2b728bda3ba64",
+                "sha256:f3f0e67e1d42de47b5c67c32c9b26641642e9170fe7e292991793705cd5fef7c",
+                "sha256:fb2cd053238d33a8ec939190f30cfd736c00653a85a2919415cecf7dc3d9da71"
+            ],
+            "markers": "python_version < '3.7'",
+            "version": "==3.7.2"
         },
         "urllib3": {
             "hashes": [

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "39fd8f61dfc7357becb2d441be0304939f3fc26951ca3b3c6e6dacb9419ea603"
+            "sha256": "f4fd556899c035d7e2bc5d5b1c6b838ce683c1a6ac987b20fef2604c85aab8c9"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -157,14 +157,6 @@
             ],
             "version": "==2.2.1"
         },
-        "dataclasses": {
-            "hashes": [
-                "sha256:454a69d788c7fda44efd71e259be79577822f5e3f53f029a22d08004e951dc9f",
-                "sha256:6988bd2b895eef432d562370bb707d540f32f7360ab13da45340101bc2307d84"
-            ],
-            "markers": "python_version < '3.7'",
-            "version": "==0.6"
-        },
         "easyqueue": {
             "hashes": [
                 "sha256:d287e911d34eae3c3c0a8d2548a6199c9fa88697183f02cdaff27c57b53dd31b"
@@ -251,13 +243,6 @@
             ],
             "version": "==2.5"
         },
-        "idna-ssl": {
-            "hashes": [
-                "sha256:a933e3bb13da54383f9e8f35dc4f9cb9eb9b3b78c6b36f311254d6d0d92c6c7c"
-            ],
-            "markers": "python_version < '3.7'",
-            "version": "==1.1.0"
-        },
         "itsdangerous": {
             "hashes": [
                 "sha256:321b033d07f2a4136d3ec762eac9f16a10ccd60f53c0c91af90217ace7ba1f19",
@@ -267,10 +252,10 @@
         },
         "jinja2": {
             "hashes": [
-                "sha256:74c935a1b8bb9a3947c50a54766a969d4846290e1e788ea44c1392163723c3bd",
-                "sha256:f84be1bb0040caca4cea721fcbbbbd61f9be9464ca236387158b0feea01914a4"
+                "sha256:065c4f02ebe7f7cf559e49ee5a95fb800a9e4528727aec6f24402a5374c65013",
+                "sha256:14dd6caf1527abb21f08f86c784eac40853ba93edb79552aa1e4b8aef1b61c7b"
             ],
-            "version": "==2.10"
+            "version": "==2.10.1"
         },
         "marathon": {
             "hashes": [
@@ -590,6 +575,13 @@
             "index": "pypi",
             "version": "==0.12.2"
         },
+        "atomicwrites": {
+            "hashes": [
+                "sha256:03472c30eb2c5d1ba9227e4c2ca66ab8287fbfbbda3888aa93dc2e28fc6811b4",
+                "sha256:75a9445bac02d8d058d5e1fe689654ba5a6556a1dfd8ce6ec55a0ed79866cfa6"
+            ],
+            "version": "==1.3.0"
+        },
         "attrs": {
             "hashes": [
                 "sha256:69c0dbf2ed392de1cb5ec704444b08a5ef81680a61cb899dc08127123af36a79",
@@ -709,13 +701,6 @@
             ],
             "version": "==2.5"
         },
-        "idna-ssl": {
-            "hashes": [
-                "sha256:a933e3bb13da54383f9e8f35dc4f9cb9eb9b3b78c6b36f311254d6d0d92c6c7c"
-            ],
-            "markers": "python_version < '3.7'",
-            "version": "==1.1.0"
-        },
         "imagesize": {
             "hashes": [
                 "sha256:3f349de3eb99145973fefb7dbe38554414e5c30abd0c8e4b970a7c9d09f3a1d8",
@@ -761,10 +746,10 @@
         },
         "jinja2": {
             "hashes": [
-                "sha256:74c935a1b8bb9a3947c50a54766a969d4846290e1e788ea44c1392163723c3bd",
-                "sha256:f84be1bb0040caca4cea721fcbbbbd61f9be9464ca236387158b0feea01914a4"
+                "sha256:065c4f02ebe7f7cf559e49ee5a95fb800a9e4528727aec6f24402a5374c65013",
+                "sha256:14dd6caf1527abb21f08f86c784eac40853ba93edb79552aa1e4b8aef1b61c7b"
             ],
-            "version": "==2.10"
+            "version": "==2.10.1"
         },
         "markupsafe": {
             "hashes": [
@@ -806,6 +791,14 @@
             ],
             "index": "pypi",
             "version": "==2.0.0"
+        },
+        "more-itertools": {
+            "hashes": [
+                "sha256:2112d2ca570bb7c3e53ea1a35cd5df42bb0fd10c45f0fb97178679c3c03d64c7",
+                "sha256:c3e4748ba1aad8dba30a4886b0b1a2004f9a863837b8654e7059eebf727afa5a"
+            ],
+            "markers": "python_version > '2.7'",
+            "version": "==7.0.0"
         },
         "multidict": {
             "hashes": [
@@ -865,10 +858,10 @@
         },
         "parso": {
             "hashes": [
-                "sha256:4580328ae3f548b358f4901e38c0578229186835f0fa0846e47369796dd5bcc9",
-                "sha256:68406ebd7eafe17f8e40e15a84b56848eccbf27d7c1feb89e93d8fca395706db"
+                "sha256:17cc2d7a945eb42c3569d4564cdf49bde221bc2b552af3eca9c1aad517dcdd33",
+                "sha256:2e9574cb12e7112a87253e14e2c380ce312060269d04bd018478a3c92ea9a376"
             ],
-            "version": "==0.3.4"
+            "version": "==0.4.0"
         },
         "pbr": {
             "hashes": [
@@ -879,11 +872,11 @@
         },
         "pexpect": {
             "hashes": [
-                "sha256:2a8e88259839571d1251d278476f3eec5db26deb73a70be5ed5dc5435e418aba",
-                "sha256:3fbd41d4caf27fa4a377bfd16fef87271099463e6fa73e92a52f92dfee5d425b"
+                "sha256:2094eefdfcf37a1fdbfb9aa090862c1a4878e5c7e0e7e7088bdb511c558e5cd1",
+                "sha256:9e2c1fd0e6ee3a49b28f95d4b33bc389c89b20af6a1255906e90ff1262ce62eb"
             ],
             "markers": "sys_platform != 'win32'",
-            "version": "==4.6.0"
+            "version": "==4.7.0"
         },
         "pickleshare": {
             "hashes": [
@@ -891,6 +884,13 @@
                 "sha256:9649af414d74d4df115d5d718f82acb59c9d418196b7b4290ed47a12ce62df56"
             ],
             "version": "==0.7.5"
+        },
+        "pluggy": {
+            "hashes": [
+                "sha256:19ecf9ce9db2fce065a7a0586e07cfb4ac8614fe96edf628a264b1c70116cf8f",
+                "sha256:84d306a647cc805219916e62aab89caa97a33a1dd8c342e87a37f91073cd4746"
+            ],
+            "version": "==0.9.0"
         },
         "prompt-toolkit": {
             "hashes": [
@@ -923,18 +923,18 @@
         },
         "pyparsing": {
             "hashes": [
-                "sha256:66c9268862641abcac4a96ba74506e594c884e3f57690a696d21ad8210ed667a",
-                "sha256:f6c5ef0d7480ad048c054c37632c67fca55299990fff127850181659eea33fc3"
+                "sha256:1873c03321fc118f4e9746baf201ff990ceb915f433f23b395f5580d1840cb2a",
+                "sha256:9b6323ef4ab914af344ba97510e966d64ba91055d6b9afa6b30799340e89cc03"
             ],
-            "version": "==2.3.1"
+            "version": "==2.4.0"
         },
         "pytest": {
             "hashes": [
-                "sha256:ba6ae459222c3ee650d9e7a3f8cbf69c23c20ed6977496e9081f3b8da19107d0",
-                "sha256:e82bc0596ee96b2287c08705cfcb6898db1fe4b5c87db3b6823f1fdd77fb3ff1"
+                "sha256:13c5e9fb5ec5179995e9357111ab089af350d788cbc944c628f3cde72285809b",
+                "sha256:f21d2f1fb8200830dcbb5d8ec466a9c9120e20d8b53c7585d180125cce1d297a"
             ],
             "index": "pypi",
-            "version": "==3.0.1"
+            "version": "==4.4.0"
         },
         "pytest-cov": {
             "hashes": [
@@ -1022,10 +1022,10 @@
         },
         "sphinxcontrib-htmlhelp": {
             "hashes": [
-                "sha256:0d691ca8edf5995fbacfe69b191914256071a94cbad03c3688dca47385c9206c",
-                "sha256:e31c8271f5a8f04b620a500c0442a7d5cfc1a732fa5c10ec363f90fe72af0cb8"
+                "sha256:4670f99f8951bd78cd4ad2ab962f798f5618b17675c35c5ac3b2132a14ea8422",
+                "sha256:d4fd39a65a625c9df86d7fa8a2d9f3cd8299a3a4b15db63b50aac9e161d8eff7"
             ],
-            "version": "==1.0.1"
+            "version": "==1.0.2"
         },
         "sphinxcontrib-jsmath": {
             "hashes": [
@@ -1043,10 +1043,10 @@
         },
         "sphinxcontrib-serializinghtml": {
             "hashes": [
-                "sha256:01d9b2617d7e8ddf7a00cae091f08f9fa4db587cc160b493141ee56710810932",
-                "sha256:392187ac558863b8aff0d76dc78e0731fed58f3b06e2b00e22995dcdb630f213"
+                "sha256:c0efb33f8052c04fd7a26c0a07f1678e8512e0faec19f4aa8f2473a8b81d5227",
+                "sha256:db6615af393650bf1151a6cd39120c29abaf93cc60db8c48eb2dddbfdc3a9768"
             ],
-            "version": "==1.1.1"
+            "version": "==1.1.3"
         },
         "toml": {
             "hashes": [
@@ -1087,15 +1087,6 @@
                 "sha256:fa4eafaa57074958f065c2a6222d8f11162739f8c9db125472a1f04794a0b91d"
             ],
             "version": "==1.1.2"
-        },
-        "typing-extensions": {
-            "hashes": [
-                "sha256:07b2c978670896022a43c4b915df8958bec4a6b84add7f2c87b2b728bda3ba64",
-                "sha256:f3f0e67e1d42de47b5c67c32c9b26641642e9170fe7e292991793705cd5fef7c",
-                "sha256:fb2cd053238d33a8ec939190f30cfd736c00653a85a2919415cecf7dc3d9da71"
-            ],
-            "markers": "python_version < '3.7'",
-            "version": "==3.7.2"
         },
         "urllib3": {
             "hashes": [

--- a/asgard/db/session.py
+++ b/asgard/db/session.py
@@ -42,9 +42,6 @@ class AsgardDBConnection:
     def begin(self):
         return self.conn.begin()
 
-    async def __aexit__(self, *args, **kwargs):
-        return await self.session.__aexit__(*args, **kwargs)
-
     async def execute(self, *args, **kwargs):
         return await self.conn.execute(*args, **kwargs)
 

--- a/asgard/db/session.py
+++ b/asgard/db/session.py
@@ -42,9 +42,6 @@ class AsgardDBConnection:
     def begin(self):
         return self.conn.begin()
 
-    async def __aiter__(self):
-        return await self.execute(self._query)
-
     async def __aexit__(self, *args, **kwargs):
         return await self.session.__aexit__(*args, **kwargs)
 

--- a/itests/asgard/db/test_session.py
+++ b/itests/asgard/db/test_session.py
@@ -78,14 +78,6 @@ class ManagedAsContextManagerTest(asynctest.TestCase):
             self.assertEqual("John Doe", result[1].tx_name)
             self.assertEqual("Outro User", result[2].tx_name)
 
-    async def test_iterate_result_with_async_for(self):
-        expected_users_data = []
-        async with self.session() as conn:
-            async for u in conn.query(User):
-                expected_users_data.append([u.id, u.tx_name, u.tx_email])
-
-        self.assertEqual(expected_users_data, self.users_fixture)
-
     async def test_query_with_model_no_filters_all_fields(self):
         async with self.session() as conn:
             self.assertEqual(2, len(list(await conn.query(User).all())))

--- a/itests/util.py
+++ b/itests/util.py
@@ -266,4 +266,4 @@ class BaseTestCase(TestCase):
                 index=index_name, doc_type="stats", body=datapoint
             )
         # para dar tempo do Elasticsearch local indexar os dados recém inseridos
-        await asyncio.sleep(1)
+        await asyncio.sleep(3)


### PR DESCRIPTION
A princípio os testes só passam no py3.6 e py.37 se o `Pipfile.lock` for gerado com py3.6.

Se o `Pipfile.lock` for feito no py3.7, o pacote `idna_ssl` não é adicionado para ser instalado. Pelo que entendi esse pacote é necessário no py3.6 mas não mais no py3.7 [1].

Quando rodamos os testes no py3.6 vemos esse erro: `ModuleNotFoundError: No module named 'idna_ssl'`.

Se gerarmos o `Pipfile.lock` estando no py3.6, esse pacote é incluído e os tesets passam tanto no py3.6 quanto no py.37. Quando rodamos no py3.7 vemos apenas um warning:

```
Ignoring idna-ssl: markers 'python_version < "3.7"' don't match your environment
```

O que temos que fazer é sempre lembrar de gerar o `Pipfile.lock` estando no 3.6. O problema é que assim que evoluírmos nosso ambiente local para 3.7 os testes vão começar a quebrar assim que instalarmos uma dependencia nova, que é quando o `Pipfile.lock` será recriado.

O mesmo problema acontece com o pacote `dataclasses`.

[1] https://github.com/aio-libs/idna-ssl/issues/5