### PR TITLE
Removendo as opções com valor `auto` do codecov

### DIFF
--- a/.circleci/codecov.yml
+++ b/.circleci/codecov.yml
@@ -8,19 +8,11 @@ coverage:
       default: off
       unittest:
         flags: unittest
-        target: auto
-        base: auto
       typehint:
         flags: typehint
-        target: auto
-        base: auto
     patch:
       default: off
       unittest:
         flags: unittest
-        target: auto
-        base: auto
       typehint:
         flags: typehint
-        target: auto
-        base: auto


### PR DESCRIPTION
A ideia é validar se esse já não é o valor padrão. Se sim, isso já vai
simplificar o config.