### PR TITLE
Adicionando badge de typehint coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,10 @@
-# Asgard API [![Build Status](https://travis-ci.org/B2W-BIT/asgard-api.svg?branch=master)](https://travis-ci.org/B2W-BIT/asgard-api) [![codecov](https://codecov.io/gh/B2W-BIT/asgard-api/branch/master/graph/badge.svg)](https://codecov.io/gh/B2W-BIT/asgard-api)
+# Asgard API [![Build Status](https://travis-ci.org/B2W-BIT/asgard-api.svg?branch=master)](https://travis-ci.org/B2W-BIT/asgard-api)
+
+|   |   |
+|---:|---|
+|Test Coverage   |[![codecov](https://codecov.io/gh/B2W-BIT/asgard-api/branch/master/graph/badge.svg?flag=unittest)](https://codecov.io/gh/B2W-BIT/asgard-api)   |
+|Typehint Coverage  |![codecov](https://codecov.io/gh/B2W-BIT/asgard-api/branch/master/graph/badge.svg?flag=typehint)   |
+
 
 https://docs.asgard.b2w.io
 


### PR DESCRIPTION
Como o codecov não premite escolher o texto que vem no badge, coloquei
em dois badges com um texto associado a cada um. Se fosse possível escolher o
texto do badge poderíamos ter os badges de volta no título, assim:

`[unittest|95%] [typehint|29%]`