### PR TITLE
Ajustando o formato do comment do codecov

### DIFF
--- a/.circleci/codecov.yml
+++ b/.circleci/codecov.yml
@@ -16,3 +16,6 @@ coverage:
         flags: unittest
       typehint:
         flags: typehint
+
+comment:
+  layout: "flags,files"


### PR DESCRIPTION
A ideia é ter o comment menos poluído. Como temos dois relatórios (typehint e unittest) o codecov faz o merge disso e a cobertura "geral" acaba ficando irreal.