### PR TITLE
Feature/accept put method to update scheduled job on root url

### DIFF
--- a/asgard/api/jobs.py
+++ b/asgard/api/jobs.py
@@ -99,7 +99,7 @@ async def create_job(request: web.Request):
     )
 
 
-@app.route(["/jobs/{job_id}"], type=RouteTypes.HTTP, methods=["PUT"])
+@app.route(["/jobs/{job_id}", "/jobs"], type=RouteTypes.HTTP, methods=["PUT"])
 @auth_required
 @validate_input
 async def update_job(request: web.Request):

--- a/itests/asgard/api/test_jobs.py
+++ b/itests/asgard/api/test_jobs.py
@@ -580,6 +580,83 @@ class JobsEndpointTestCase(BaseTestCase):
         self.assertEqual(asgard_job.cpus, updated_job_resource.job.cpus)
         self.assertEqual(asgard_job.mem, updated_job_resource.job.mem)
 
+    @with_json_fixture("scheduled-jobs/chronos/dev-another-job.json")
+    @with_json_fixture("scheduled-jobs/chronos/dev-with-infra-in-name.json")
+    async def test_update_job_job_exist_use_job_id_from_url(
+        self, dev_job_fixture, dev_with_infra_fixture
+    ):
+        """
+        Confirmamos que é possível fazer um PUT /jobs e atualizar um job.
+        O id do job usado deve ser o id que está na URL.
+
+        Conferimos que:
+            mesmo que o payalod tenha {"id": "other-job"} um PUT /jobs/my-job
+            atualiza o registro do `my-job`.
+        """
+        await _load_jobs_into_chronos(dev_job_fixture, dev_with_infra_fixture)
+        asgard_job = ChronosScheduledJobConverter.to_asgard_model(
+            ChronosJob(**dev_job_fixture)
+        ).remove_namespace(self.account)
+
+        original_asgard_job_id = asgard_job.id
+
+        dev_with_infra_job = ChronosScheduledJobConverter.to_asgard_model(
+            ChronosJob(**dev_with_infra_fixture)
+        ).remove_namespace(self.account)
+
+        self.assertEqual(asgard_job.cpus, dev_job_fixture["cpus"])
+        self.assertEqual(asgard_job.mem, dev_job_fixture["mem"])
+
+        # Mandamos um payload contendo o id de outro job
+        asgard_job.id = dev_with_infra_job.id
+
+        asgard_job.cpus = 2
+        asgard_job.mem = 2048
+
+        resp = await self.client.put(
+            f"/jobs/{original_asgard_job_id}",
+            headers={
+                "Authorization": f"Token {USER_WITH_MULTIPLE_ACCOUNTS_AUTH_KEY}"
+            },
+            json=asgard_job.dict(),
+        )
+        self.assertEqual(HTTPStatus.ACCEPTED, resp.status)
+
+        await asyncio.sleep(0.5)
+        updated_job_response = await self.client.get(
+            f"/jobs/{original_asgard_job_id}",
+            headers={
+                "Authorization": f"Token {USER_WITH_MULTIPLE_ACCOUNTS_AUTH_KEY}"
+            },
+        )
+        updated_job_data = await updated_job_response.json()
+        updated_job_resource = CreateScheduledJobResource(**updated_job_data)
+        self.assertEqual(
+            asgard_job.cpus, updated_job_resource.job.cpus, "não ajustou CPU"
+        )
+        self.assertEqual(
+            asgard_job.mem, updated_job_resource.job.mem, "Não ajustou MEM"
+        )
+
+        dev_with_infra_response = await self.client.get(
+            f"/jobs/{dev_with_infra_job.id}",
+            headers={
+                "Authorization": f"Token {USER_WITH_MULTIPLE_ACCOUNTS_AUTH_KEY}"
+            },
+        )
+        dev_with_infra_data = await dev_with_infra_response.json()
+        resource = CreateScheduledJobResource(**dev_with_infra_data)
+        self.assertEqual(
+            dev_with_infra_job.cpus,
+            resource.job.cpus,
+            "Ajustou CPU da app errada",
+        )
+        self.assertEqual(
+            dev_with_infra_job.mem,
+            resource.job.mem,
+            "Ajustou MEM da app errada",
+        )
+
     @with_json_fixture("scheduled-jobs/chronos/dev-with-infra-in-name.json")
     async def test_update_job_body_without_job_id(self, dev_job_fixture):
         """


### PR DESCRIPTION
Mesmo com a correção, um `PUT /jobs/{job_id}` ainda requer um JSON no body que **contenha** o campo `id`.

Para podermos fazer isso sem requerer o campo `id` teríamos que remapear todos os Resources (e sub-resources) que estão em `asgard.api.resources.jobs` e acho que isso é uma tarefa bem meior do que esse fix.

O campo só é obrigatório pois o handler usa o próprio model `asgard.models.job.ScheduledJob`.

O que tentei fazer foi mapear um novo resource assim:

```python
class ScheduledJobUpdateResource(ScheduledJob):
  id: Optional[str]
```

Mas o pydantic não permite pois a baseclass do `ScheduledJob` declara o `id` como `id: str`.
