### PR TITLE
Movendo patched_startup para asgard.app

### DIFF
--- a/asgard/api/agents.py
+++ b/asgard/api/agents.py
@@ -1,10 +1,8 @@
 from decimal import Decimal
 from typing import Any, Dict, List
 
-import aiohttp_cors
 from aiohttp import web
 from asyncworker import RouteTypes
-from asyncworker.conf import settings
 
 from asgard.api.resources.agents import AgentsResource
 from asgard.api.resources.apps import AppsResource
@@ -95,42 +93,3 @@ async def agent_apps(request: web.Request):
     if agent:
         apps = agent.applications
     return web.json_response(AppsResource(apps=apps).dict())
-
-
-async def patched_startup(app):
-
-    app[RouteTypes.HTTP] = {}
-    routes = app.routes_registry.http_routes
-    if not routes:
-        return
-
-    app[RouteTypes.HTTP]["app"] = http_app = web.Application()
-    for route in routes:
-        http_app.router.add_route(**route)
-
-    cors = aiohttp_cors.setup(
-        http_app,
-        defaults={
-            "*": aiohttp_cors.ResourceOptions(
-                allow_credentials=True, expose_headers="*", allow_headers="*"
-            )
-        },
-    )
-
-    # Configure CORS on all routes.
-    for route in list(http_app.router.routes()):
-        cors.add(route)
-
-    app[RouteTypes.HTTP]["runner"] = web.AppRunner(http_app)
-    await app[RouteTypes.HTTP]["runner"].setup()
-    app[RouteTypes.HTTP]["site"] = web.TCPSite(
-        runner=app[RouteTypes.HTTP]["runner"],
-        host=settings.HTTP_HOST,
-        port=settings.HTTP_PORT,
-    )
-
-    await app[RouteTypes.HTTP]["site"].start()
-
-
-app._on_startup.clear()
-app._on_startup.append(patched_startup)

--- a/asgard/app.py
+++ b/asgard/app.py
@@ -17,8 +17,6 @@ async def patched_startup(app):
 
     app[RouteTypes.HTTP] = {}
     routes = app.routes_registry.http_routes
-    if not routes:
-        return
 
     app[RouteTypes.HTTP]["app"] = http_app = web.Application()
     for route in routes:

--- a/asgard/app.py
+++ b/asgard/app.py
@@ -1,4 +1,7 @@
-from asyncworker import App
+import aiohttp_cors
+from aiohttp import web
+from asyncworker import App, RouteTypes
+from asyncworker.conf import settings
 
 from asgard import conf
 
@@ -8,3 +11,42 @@ app = App(
     password=conf.ASGARD_RABBITMQ_PASS,
     prefetch_count=conf.ASGARD_RABBITMQ_PREFETCH,
 )
+
+
+async def patched_startup(app):
+
+    app[RouteTypes.HTTP] = {}
+    routes = app.routes_registry.http_routes
+    if not routes:
+        return
+
+    app[RouteTypes.HTTP]["app"] = http_app = web.Application()
+    for route in routes:
+        http_app.router.add_route(**route)
+
+    cors = aiohttp_cors.setup(
+        http_app,
+        defaults={
+            "*": aiohttp_cors.ResourceOptions(
+                allow_credentials=True, expose_headers="*", allow_headers="*"
+            )
+        },
+    )
+
+    # Configure CORS on all routes.
+    for route in list(http_app.router.routes()):
+        cors.add(route)
+
+    app[RouteTypes.HTTP]["runner"] = web.AppRunner(http_app)
+    await app[RouteTypes.HTTP]["runner"].setup()
+    app[RouteTypes.HTTP]["site"] = web.TCPSite(
+        runner=app[RouteTypes.HTTP]["runner"],
+        host=settings.HTTP_HOST,
+        port=settings.HTTP_PORT,
+    )
+
+    await app[RouteTypes.HTTP]["site"].start()
+
+
+app._on_startup.clear()
+app._on_startup.append(patched_startup)

--- a/itests/asgard/test_patched_startup.py
+++ b/itests/asgard/test_patched_startup.py
@@ -35,3 +35,19 @@ class PatchedStartupAppTest(TestCase):
             "server.com", resp.headers.get("Access-Control-Allow-Origin")
         )
         await app.shutdown()
+
+    async def test_patched_startup_app_without_routes(self):
+        app = App("", "", "", 1)
+        app._on_startup.clear()
+        app._on_startup.append(patched_startup)
+
+        client = ClientSession()
+        await app.startup()
+        resp = await client.get(
+            f"http://{settings.HTTP_HOST}:{settings.HTTP_PORT}/new-path",
+            headers={"Origin": "server.com"},
+        )
+        self.assertEqual(HTTPStatus.NOT_FOUND, resp.status)
+
+        self.assertFalse("Access-Control-Allow-Origin" in resp.headers)
+        await app.shutdown()

--- a/itests/asgard/test_patched_startup.py
+++ b/itests/asgard/test_patched_startup.py
@@ -1,0 +1,37 @@
+from http import HTTPStatus
+
+from aiohttp import web, ClientSession
+from asynctest import TestCase
+from asyncworker import RouteTypes, App
+from asyncworker.conf import settings
+
+from asgard.app import patched_startup
+
+
+class PatchedStartupAppTest(TestCase):
+    async def test_patched_startup_has_cors_configured(self):
+
+        app = App("", "", "", 1)
+        app._on_startup.clear()
+        app._on_startup.append(patched_startup)
+
+        @app.route(["/new-path"], type=RouteTypes.HTTP, methods=["GET"])
+        async def handler(r):
+            return web.json_response({})
+
+        client = ClientSession()
+        await app.startup()
+        resp = await client.get(
+            f"http://{settings.HTTP_HOST}:{settings.HTTP_PORT}/new-path",
+            headers={"Origin": "server.com"},
+        )
+        self.assertEqual(HTTPStatus.OK, resp.status)
+
+        self.assertTrue(
+            "Access-Control-Allow-Origin" in resp.headers,
+            "Header do CORS não encontrado",
+        )
+        self.assertEqual(
+            "server.com", resp.headers.get("Access-Control-Allow-Origin")
+        )
+        await app.shutdown()


### PR DESCRIPTION
Acabou ficando perdido no asgard.api.agents

Esse código existe por uma falta de funcionalidade no asynworker.
O asyncworker até possui uma infra-estrutura de `startup()` e
`shutdown()` mas ele atualmente faz isso **após** o "listen" da app
http. E o aiohttp não permite mexer na app após esse ponto.

O que esse patched_startup faz é configurar um CORS (ainda inseguro)
para todas as rotas. E precisamos fazer isso antes do "listen".

Quando o asyncworker tiver esse processo de startup divido em dois (pre
listen e pos-listen) poderemos remover esse código.